### PR TITLE
Apply default protocol when using www prefix and resolve spacing issue

### DIFF
--- a/js/chatutil.js
+++ b/js/chatutil.js
@@ -17,9 +17,14 @@ function ProcessText(text, allow_newline) {
 
                var link_end = text.indexOf(" ", index);
                var link = (link_end == -1 ? text.substr(index) : text.substr(index, link_end - index));
+               var displayLink = htmlify(link);
+               
+               if(link.substr(0, 4) === "www.") {
+                   link = "http://" + link;
+               }
 
-               result_text += '<a href="'+link+'" target="_blank">' + htmlify(link) + '</a>';
-               index += link.length;
+               result_text += '<a href="' + link + '" target="_blank">' + displayLink + '</a>';
+               index += displayLink.length - 1;
                has_content = true;
 
         } else if(text[index] == '&') {


### PR DESCRIPTION
[commit 	fa3ae84]
Currently using www. to create a link within the chat will open the browser with the remote host url. This is because a protocol is not defined, and the browser assumes you're trying to open a file. This will create a link with the default http protocol.

There is also an issue with spacing after creating a link. http://test.com &btest will mash the url and the text together, even though a space exists. Off by one!
