### PR TITLE
Chat alignment and twelve hour midnight noon

### DIFF
--- a/css/lobby.css
+++ b/css/lobby.css
@@ -1128,9 +1128,9 @@ div.chat_element_text
 
 div.chat_element_time
 {
-    font-family: TempestaSeven, Verdana, sans-serif;
+    font-family: Verdana, sans-serif;
     text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
-    font-size: 6pt;
+    font-size: 8pt;
     color: rgba(222, 229, 243, 0.7);
     display: inline-block;
     text-align: left;
@@ -1140,7 +1140,7 @@ div.chat_element_time
 
 
 div.chat_element_title {
-    font-family: TempestaSeven, Verdana, sans-serif;
+    font-family: Verdana, sans-serif;
     text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
     font-size: 5pt;
     color: rgba(164, 168, 127, 0.7);

--- a/css/lobby.css
+++ b/css/lobby.css
@@ -1130,7 +1130,7 @@ div.chat_element_time
 {
     font-family: Verdana, sans-serif;
     text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
-    font-size: 8pt;
+    font-size: 7pt;
     color: rgba(222, 229, 243, 0.7);
     display: inline-block;
     text-align: left;

--- a/css/lobby.css
+++ b/css/lobby.css
@@ -1140,7 +1140,7 @@ div.chat_element_time
 
 
 div.chat_element_title {
-    font-family: Verdana, sans-serif;
+    font-family: TempestaSeven, Verdana, sans-serif;
     text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
     font-size: 5pt;
     color: rgba(164, 168, 127, 0.7);

--- a/js/chatutil.js
+++ b/js/chatutil.js
@@ -174,12 +174,11 @@ function GenerateChatHTML(chat_msg) {
         
         if(local_data.m_Persistent.m_TwelveHourClock) {
             hours_suffix = hours_val >= 12 ? " PM" : " AM";
-            hours_val = hours_val % 12;
+            hours_val = ((hours_val + 11) % 12 + 1);
         }
 
         var hours = hours_val.toString();
         var minutes = msg_time.getMinutes().toString();
-
 
         if(hours.length < 2) {
             hours = "0" + hours;


### PR DESCRIPTION
Fixes #27 

TempestaSeven has different width sizes for each of its characters, so its possible for the text within [] to vary.

Also resolves an edge case where the time is 12 (noon or midnight)

New behavior:
![new_font](https://cloud.githubusercontent.com/assets/6980197/23448052/c7b38b00-fe1c-11e6-9cfe-1b1195feb297.png)
