### PR TITLE
Set focus to chatinput box when changing channel

### DIFF
--- a/js/chatdata.js
+++ b/js/chatdata.js
@@ -238,6 +238,8 @@ function ClearChatPlayers(channel_id) {
 }
 
 function SetCurrentChannel(channel_id) {
+    dom_data.chatinput.focus();
+    
     if(chat_data.current_channel == channel_id) {
         return;
     }


### PR DESCRIPTION
When setting the active channel, the focus will be given to the chat input textbox.